### PR TITLE
fix: harden go workflow result handling + LF for workflow scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The Workflow engine's permission layer rejects scripts containing CR bytes
+# ("control characters that would be hidden in the approval dialog"), so
+# workflow scripts must check out as LF regardless of core.autocrlf.
+ship/workflows/*.js text eol=lf

--- a/ship/workflows/go.workflow.js
+++ b/ship/workflows/go.workflow.js
@@ -150,7 +150,7 @@ Execute all pending tasks ${ph.id === 'all' ? 'in the plan' : 'in this phase'}. 
 const reviewPrompt = (ph, commits) => `Review feature: ${feature}
 ${phaseLine(ph)}Phase commits: ${commits.length ? commits.join(', ') : '(none reported)'}
 
-Determine the diff range from the first phase commit (\`<first-commit>~1..HEAD\`; if no commits were reported, review the working tree against the merge-base). Re-run each task's verify command (trust-but-verify), then review the phase diff. Read .planning/features/${feature}/PLAN.md and .planning/features/${feature}/CONTEXT.md.`
+Determine the diff range from the phase commits — confirm their order with \`git log\` and diff \`<oldest-phase-commit>~1..HEAD\` (if no commits were reported, review the uncommitted working-tree changes via \`git diff HEAD\`). Re-run each task's verify command (trust-but-verify), then review the phase diff. Read .planning/features/${feature}/PLAN.md and .planning/features/${feature}/CONTEXT.md.`
 
 const fixPrompt = (ph, findings) => `Fix review findings for feature: ${feature}
 ${phaseLine(ph)}
@@ -193,7 +193,9 @@ for (let i = 0; i < phases.length; i++) {
 
   let fixRound = null
   let rereview = null
-  const blocking = review && review.status === 'NEEDS_FIXES'
+  // Trust the findings over the verdict: an APPROVED review that still lists
+  // critical/high findings is contradictory and must not skip the fix round.
+  const blocking = review
     ? review.findings.filter((f) => f.severity === 'critical' || f.severity === 'high')
     : []
 
@@ -212,14 +214,19 @@ for (let i = 0; i < phases.length; i++) {
   // silently claiming a clean phase.
   const unresolved = blocking.length && !rereview
     ? blocking
-    : rereview && rereview.status === 'NEEDS_FIXES'
+    : rereview
       ? rereview.findings.filter((f) => f.severity === 'critical' || f.severity === 'high')
       : []
 
   completed.push({
     phaseId: ph.id, phaseName: ph.name,
     tasksCompleted: build.tasks_completed, tasksTotal: build.tasks_total,
-    commits: build.commits || [], concerns: build.concerns || [],
+    commits: build.commits || [],
+    // A dead reviewer must not read as a clean phase — surface it through the
+    // concerns channel the go skill already reports to the user.
+    concerns: review
+      ? build.concerns || []
+      : [...(build.concerns || []), `phase ${label} review never ran (no result after retry) — the diff went unreviewed`],
     reviewStatus: review ? review.status : 'SKIPPED',
     findings: review ? review.findings : [],
     fixApplied: !!fixRound, unresolved,

--- a/tests/rearchitecture-v4.test.js
+++ b/tests/rearchitecture-v4.test.js
@@ -258,6 +258,26 @@ describe('v4 — go workflow control flow', () => {
     assert.equal(result.completed[0].unresolved[0].severity, 'high');
   });
 
+  it('APPROVED review that still lists critical findings triggers the fix round', async () => {
+    const CONTRADICTORY = { feature: 'f', status: 'APPROVED',
+      findings: [{ severity: 'critical', file: 'x.js:1', description: 'real bug' }] };
+    const { result, calls } = await runWorkflow(
+      { feature: 'f', phases: [{ id: 'p1', name: 'A' }] },
+      { 'build:': COMPLETE, 'review:': CONTRADICTORY, 'fix:': COMPLETE, 'rereview:': APPROVED, 'verify': VERDICT, __default: APPROVED });
+    assert.deepEqual(calls, ['build:p1', 'review:p1', 'fix:p1', 'rereview:p1', 'verify']);
+    assert.equal(result.completed[0].fixApplied, true, 'findings must outrank a contradictory verdict');
+  });
+
+  it('a dead reviewer surfaces as a phase concern, not a clean phase', async () => {
+    const { result } = await runWorkflow(
+      { feature: 'f', phases: [{ id: 'p1', name: 'A' }] },
+      { 'build:': COMPLETE, 'verify': VERDICT, __default: APPROVED,
+        'review:': () => { throw new Error('schema wrapper flake'); } });
+    assert.equal(result.completed[0].reviewStatus, 'SKIPPED');
+    assert.ok(result.completed[0].concerns.some((c) => /review never ran/.test(c)),
+      'a skipped review must be surfaced in concerns');
+  });
+
   it('throws when args.feature is missing', async () => {
     await assert.rejects(() => runWorkflow({ phases: [] }, { __default: APPROVED }), /feature is required/);
   });


### PR DESCRIPTION
Hardens `ship/workflows/go.workflow.js` result handling, from a code review of the 4.1.0 script. Independent of #5 (which froze this file); no schema or contract changes — the returned shape and all agent prompts' contracts are unchanged.

## Summary
- **Trust findings over the verdict:** a review result of `APPROVED` that still lists critical/high findings previously skipped the fix round and recorded the findings as informational. Blocking findings are now derived from severities regardless of the reviewer's verdict.
- **A dead reviewer is no longer silent:** when both review attempts fail, the phase previously completed with `reviewStatus: 'SKIPPED'` and nothing user-visible. It now injects a concern (`"phase N review never ran … the diff went unreviewed"`) into the channel the go skill already reports.
- **Diff-range prompt no longer assumes commit order:** the review prompt derived the phase diff as `<first-commit>~1..HEAD`, silently narrowing the reviewed diff to one commit if a builder ever reported commits newest-first. The reviewer is now told to confirm ordering with `git log`; the ill-defined merge-base fallback is replaced with `git diff HEAD`.
- **`.gitattributes` forces LF for workflow scripts:** the Workflow engine's permission layer rejects scripts containing CR bytes ("control characters that would be hidden in the approval dialog") — hit in the field on Windows, where `core.autocrlf` checks the plugin cache copy out as CRLF and `/ship:go` fails to launch. The index already stores the file as LF, so this is checkout behavior only, no renormalization.

## Test plan
- Two new control-flow dry-run tests: `APPROVED`-with-critical-findings triggers the fix round; a reviewer that dies twice surfaces in `concerns`
- `node --test "tests/*.test.js"` — 66/66 pass
- Existing dry-run scenarios (happy path, fix round, checkpoint, retry/degrade, unresolved-on-dead-rereview) unchanged and green

Built with [Ship](https://github.com/dilhanz/ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
