### PR TITLE
fix: verify-FAIL fix rounds re-enter /ship:go; record skipped reviews

### DIFF
--- a/agents/ship-verifier.md
+++ b/agents/ship-verifier.md
@@ -82,7 +82,7 @@ Read the template at `${CLAUDE_PLUGIN_ROOT}/ship/templates/VERIFY.md` and write 
 
 Update CONTEXT.md frontmatter:
 - PASS or INCONCLUSIVE → `status: done` (INCONCLUSIVE gaps are recorded in VERIFY.md; the override gate lives in `/ship:finish`)
-- FAIL → `status: plan-verified`, and append Fix Tasks to PLAN.md for each failing criterion and critical/high bug.
+- FAIL → `status: plan-verified`, and append Fix Tasks to PLAN.md for each failing criterion and critical/high bug. In a phased plan, wrap them in a new pending phase — `<phase id="fix-1" name="Verify fix round 1" status="pending">` (increment the id on repeat failures) — so `/ship:go` and `/ship:build` pick them up as the next pending phase; in a flat plan, append them as bare tasks.
 
 ## Output
 

--- a/skills/go/SKILL.md
+++ b/skills/go/SKILL.md
@@ -36,7 +36,7 @@ Fires when status is `plan-verified` (whether plan-verify just ran or the featur
 
 ## 4. Pre-Build Prep
 
-1. From PLAN.md, build the ordered list of **pending phases** (each `<phase>` whose `status` != `done`, as `{id, name}`). If the plan is flat (no `<phase>` elements), use a single pseudo-phase `{id: "all", name: "all"}`.
+1. From PLAN.md, build the ordered list of **pending phases** (each `<phase>` whose `status` != `done`, as `{id, name}`). If the plan is flat (no `<phase>` elements), use a single pseudo-phase `{id: "all", name: "all"}`. If no pending phases remain but pending `<task>`s exist outside any phase (fix tasks appended by an older verifier), also use the `{id: "all", name: "all"}` pseudo-phase — its builder prompt says to execute all pending tasks in the plan, which sweeps them up.
 2. If status is `built` (build already complete, verify only), use an **empty** phase list — the workflow will skip straight to verify.
 3. Set CONTEXT.md frontmatter `status: building` (unless already `built`).
 
@@ -58,7 +58,7 @@ The workflow builds each phase (builder → reviewer re-verify+review → one fi
 From the returned result:
 
 1. For each phase in `completed`, mark its `<phase>` `status="done"` in PLAN.md (skip the `all` pseudo-phase).
-2. Persist review findings to `.planning/features/{name}/REVIEW.md` (create on first append), same format as the manual build skill: a `## Phase {id} — {phase-name} (round 1)` heading with `Status: {reviewStatus}`, then one line per finding: `- [{severity}] {file}: {description} — {marker}`. Marker: `unresolved` if the finding appears in that phase's `unresolved` list; `fixed in fix round` for other critical/high findings when `fixApplied` is true; `recorded` otherwise. Skip phases with an empty `findings` array.
+2. Persist review findings to `.planning/features/{name}/REVIEW.md` (create on first append), same format as the manual build skill: a `## Phase {id} — {phase-name} (round 1)` heading with `Status: {reviewStatus}`, then one line per finding: `- [{severity}] {file}: {description} — {marker}`. Marker: `unresolved` if the finding appears in that phase's `unresolved` list; `fixed in fix round` for other critical/high findings when `fixApplied` is true; `recorded` otherwise. Skip phases with an empty `findings` array — except when `reviewStatus` is `SKIPPED`: an unreviewed phase must still get its heading with `Status: SKIPPED`, so REVIEW.md durably records that the diff went unreviewed.
 3. Collect any per-phase `unresolved` review findings (critical/high that survived the fix round) and builder `concerns` across `completed`. These must be surfaced in the report below — a phase is marked `done` even when it carries unresolved findings (one fix round only, the verifier is the backstop), so the user needs to see them.
 4. **If `stoppedAt` is set** (a build phase returned `CHECKPOINT`, `NEEDS_CONTEXT`, or no result): leave CONTEXT.md `status: building` and report the blocker. For `NEEDS_CONTEXT`, tell the user to run `/ship:build {name}` — the manual build handles interactive context collection (the unattended workflow cannot prompt mid-run).
 5. **If a `verdict` is present:** the verifier already set CONTEXT.md status (`done` on PASS/INCONCLUSIVE, `plan-verified` + fix tasks on FAIL). Report it.
@@ -78,7 +78,7 @@ Verify: {PASS | FAIL | INCONCLUSIVE — criteria_passed/criteria_total, bugs by 
 - {phase id}: {concern}
 
 [If verdict PASS/INCONCLUSIVE:] Ready to finish — run /ship:finish (or I can run it now).
-[If FAIL:] Fix tasks were appended to PLAN.md. Review them, then /ship:build and /ship:go to continue.
+[If FAIL:] Fix tasks were appended to PLAN.md as a pending fix phase. Review them, then /ship:go to continue (or /ship:build for manual control).
 [If stoppedAt:] Stopped at phase {id}. Reason: {status}. Next: {suggested action}.
 ```
 

--- a/tests/doctrine-v5.test.js
+++ b/tests/doctrine-v5.test.js
@@ -127,3 +127,27 @@ describe('v5 — frozen contracts', () => {
       'builder keeps the HARD-GATE');
   });
 });
+
+// ---------------------------------------------------------------------------
+// FAIL → rebuild re-entry (v5.0.2) — fix rounds must reach both build paths
+// ---------------------------------------------------------------------------
+
+describe('v5 — verify fix rounds re-enter the build paths', () => {
+  it('verifier wraps fix tasks in a pending phase on phased plans', () => {
+    const c = readSrc('agents/ship-verifier.md');
+    assert.ok(c.includes('fix-1') && c.includes('<phase'),
+      'verifier must wrap FAIL fix tasks in a new pending <phase> so go/build pick them up');
+  });
+
+  it('go skill sweeps orphaned fix tasks into the pseudo-phase', () => {
+    const c = readSrc('skills/go/SKILL.md');
+    assert.ok(c.includes('outside any phase'),
+      'go must route pending tasks outside phases through the {id: "all"} pseudo-phase');
+  });
+
+  it('go skill records skipped reviews in REVIEW.md', () => {
+    const c = readSrc('skills/go/SKILL.md');
+    assert.ok(c.includes('Status: SKIPPED') || c.includes('`SKIPPED`'),
+      'an unreviewed phase must still be recorded in REVIEW.md, not silently skipped');
+  });
+});


### PR DESCRIPTION
Fixes two gaps found reviewing `skills/go/SKILL.md` against the workflow contract.

## Summary
- **Verify FAIL now re-enters `/ship:go` on phased plans.** The verifier appended fix tasks to PLAN.md as bare `<task>` elements. On a phased plan (all phases `done`), `/ship:go`'s pending-phase extraction found nothing, passed `phases: []` to the workflow, and skipped straight to verify-only — re-running the verifier against unfixed code and appending duplicate fix tasks in a loop. The verifier now wraps fix tasks in a new pending phase (`<phase id="fix-1" name="Verify fix round 1">`, incrementing on repeat failures), so both `/ship:go` and `/ship:build` pick them up as the next pending phase. Flat plans were already fine via the `{id: "all"}` pseudo-phase. The go skill also gains a safety net: pending tasks outside any phase (from plans written by an older verifier) are swept into the pseudo-phase. The FAIL report line now says `/ship:go` continues the loop, instead of the old `/ship:build`-then-`/ship:go` workaround.
- **Skipped reviews are durably recorded.** REVIEW.md's write rule skipped phases with empty findings — which meant a phase whose reviewer died twice (`reviewStatus: 'SKIPPED'`, findings `[]`) was exactly the phase REVIEW.md stayed silent about; the 5.0.1 dead-reviewer concern only reached the chat report. An unreviewed phase now still gets its REVIEW.md heading with `Status: SKIPPED`.

## Test plan
- Three new doctrine assertions: verifier wraps fix tasks in a pending phase; go sweeps orphaned fix tasks into the pseudo-phase; go records skipped reviews in REVIEW.md
- `node --test "tests/*.test.js"` — 90/90 pass

Built with [Ship](https://github.com/dilhanz/ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
