### PR TITLE
ci: publish the GitHub release from a pushed version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Cuts the GitHub release when a version tag is pushed:
+#   git tag -a v5.1.0 -m "..." main && git push origin v5.1.0
+#
+# Release notes come from the matching CHANGELOG.md section, so the changelog
+# entry is written once (in the PR that bumps the version) and never retyped.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # The version lives in three files plus the tag. A mismatch means the
+      # release bump was incomplete — better to fail here than to publish a
+      # release whose artifacts disagree with its name.
+      - name: Check the tag matches the version files
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          for file in ship/VERSION package.json .claude-plugin/plugin.json; do
+            case "$file" in
+              ship/VERSION) found=$(tr -d '[:space:]' < "$file") ;;
+              *) found=$(node -p "require('./$file').version") ;;
+            esac
+            if [ "$found" != "$tag" ]; then
+              echo "::error file=$file::$file is at $found but the tag is v$tag"
+              exit 1
+            fi
+          done
+          echo "All version files agree: $tag"
+
+      - name: Run tests
+        run: node --test "tests/*.test.js"
+
+      - name: Extract the release notes from CHANGELOG.md
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          awk -v v="$tag" '
+            $0 == "## " v { capture = 1; next }
+            capture && /^## / { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error file=CHANGELOG.md::no '## $tag' section found in CHANGELOG.md"
+            exit 1
+          fi
+          cat release-notes.md
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            --verify-tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,16 @@ The VERIFY.md template in `ship/templates/` is read at runtime by the verifier a
 
 Use `node --test` (Node.js built-in test runner). Test files go in the `tests/` directory.
 
+### Releasing
+
+The version lives in three files — `ship/VERSION`, `package.json`, `.claude-plugin/plugin.json` — and they must agree. Bump all three plus a `## {version}` CHANGELOG entry in the release PR, then tag `main` after merge:
+
+```bash
+git tag -a v5.1.0 -m "v5.1.0 — short description" main && git push origin v5.1.0
+```
+
+`.github/workflows/release.yml` takes it from there: it checks the tag against the three version files, runs the test suite, extracts the matching CHANGELOG section as the release notes, and publishes the GitHub release. A version mismatch or a missing CHANGELOG section fails the run instead of publishing.
+
 ### Commit Conventions
 
 ```


### PR DESCRIPTION
## Problem

Releases are cut by hand: the CHANGELOG entry gets retyped into the release body, and nothing checks that the tag agrees with the three files carrying the version (`ship/VERSION`, `package.json`, `.claude-plugin/plugin.json`).

## Change

`.github/workflows/release.yml` — pushing a `v*` tag now publishes the release:

1. **Version guard** — fails if the tag (minus the `v`) doesn't match all three version files, pointing at the file that disagrees.
2. **Tests** — `node --test "tests/*.test.js"` on Node 22.
3. **Release notes** — awk extracts the `## {version}` section from `CHANGELOG.md`; an empty result fails the run rather than publishing an empty release.
4. **Publish** — `gh release create` with `--verify-tag`, titled `v{version}`, using the built-in `GITHUB_TOKEN` (`permissions: contents: write`, no extra secrets).

The workflow only reads the changelog — the release body stays authored in the version-bump PR, matching how v5.0.0–v5.0.2 read today.

`CLAUDE.md` gains a short **Releasing** section documenting the bump-three-files-then-tag flow.

## Usage

```bash
git tag -a v5.1.0 -m "v5.1.0 — builder turn-budget continuation" main
git push origin v5.1.0
```

Pushing that tag also backfills the v5.1.0 release from #8, which is currently merged but unreleased.

## Testing

The two scripted steps were run against this repo's real files:

- version guard — all three files report `5.1.0`, matching the tag
- extraction — the `## 5.1.0` section comes out complete (summary + `### Fixed` + `### Changed`); a nonexistent version yields 0 bytes, which trips the guard

The workflow YAML parses. The publish step itself only runs on a real tag push, so it's unexercised until the first tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_013yF1AnjoCd6sEi9BABv57e)_