### PR TITLE
ci: allow releasing an existing tag from the Actions tab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,45 @@ name: Release
 #
 # Release notes come from the matching CHANGELOG.md section, so the changelog
 # entry is written once (in the PR that bumps the version) and never retyped.
+#
+# The same job can be run by hand from the Actions tab (Run workflow → tag) for
+# a tag that was pushed before this workflow existed, or to retry a publish that
+# failed. Everything is read from the tagged commit either way, so a manual run
+# publishes exactly what an automatic one would.
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing version tag to release (e.g. v5.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Check the tag looks like a version tag
+        run: |
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) echo "::error::'$TAG' is not a version tag (expected v{major}.{minor}.{patch})"; exit 1 ;;
+          esac
+
+      # Read everything from the tagged commit, not from the default branch, so
+      # a manual run publishes the same content the tag push would have.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -29,32 +54,43 @@ jobs:
       # release whose artifacts disagree with its name.
       - name: Check the tag matches the version files
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          version="${TAG#v}"
           for file in ship/VERSION package.json .claude-plugin/plugin.json; do
             case "$file" in
               ship/VERSION) found=$(tr -d '[:space:]' < "$file") ;;
               *) found=$(node -p "require('./$file').version") ;;
             esac
-            if [ "$found" != "$tag" ]; then
-              echo "::error file=$file::$file is at $found but the tag is v$tag"
+            if [ "$found" != "$version" ]; then
+              echo "::error file=$file::$file is at $found but the tag is $TAG"
               exit 1
             fi
           done
-          echo "All version files agree: $tag"
+          echo "All version files agree: $version"
+
+      # A published release is not something to overwrite by accident — a
+      # re-run against an already-released tag stops here.
+      - name: Check the release does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::$TAG is already released — delete the release first to republish"
+            exit 1
+          fi
 
       - name: Run tests
         run: node --test "tests/*.test.js"
 
       - name: Extract the release notes from CHANGELOG.md
         run: |
-          tag="${GITHUB_REF_NAME#v}"
-          awk -v v="$tag" '
+          version="${TAG#v}"
+          awk -v v="$version" '
             $0 == "## " v { capture = 1; next }
             capture && /^## / { exit }
             capture { print }
           ' CHANGELOG.md > release-notes.md
           if [ ! -s release-notes.md ]; then
-            echo "::error file=CHANGELOG.md::no '## $tag' section found in CHANGELOG.md"
+            echo "::error file=CHANGELOG.md::no '## $version' section found in CHANGELOG.md"
             exit 1
           fi
           cat release-notes.md
@@ -63,7 +99,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --notes-file release-notes.md \
             --verify-tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,9 @@ The version lives in three files — `ship/VERSION`, `package.json`, `.claude-pl
 git tag -a v5.1.0 -m "v5.1.0 — short description" main && git push origin v5.1.0
 ```
 
-`.github/workflows/release.yml` takes it from there: it checks the tag against the three version files, runs the test suite, extracts the matching CHANGELOG section as the release notes, and publishes the GitHub release. A version mismatch or a missing CHANGELOG section fails the run instead of publishing.
+`.github/workflows/release.yml` takes it from there: it checks the tag against the three version files, runs the test suite, extracts the matching CHANGELOG section as the release notes, and publishes the GitHub release. A version mismatch, a missing CHANGELOG section, or a tag that is already released fails the run instead of publishing.
+
+The same job runs from the Actions tab (**Run workflow** → tag) for a tag pushed before the workflow existed, or to retry a failed publish. It reads the tagged commit either way, so a manual run publishes exactly what the tag push would have.
 
 ### Commit Conventions
 


### PR DESCRIPTION
## Problem

Tag-triggered workflows run the workflow file *as it exists at the tagged commit*. `v5.1.0` was pushed at `accc3bb`, which predates `.github/workflows/release.yml` (#9), so it can never publish itself — the tag is on the remote, but there's no v5.1.0 release and `release.yml` has 0 runs. The same gap means a publish that fails after the tag is already pushed has no retry path short of moving the tag.

## Change

`release.yml` gains a `workflow_dispatch` trigger taking an existing tag:

- **`env.TAG`** resolves to `inputs.tag || github.ref_name`, so every step reads one value regardless of trigger.
- **Checkout uses `ref: <tag>`** — the version guard, tests, and changelog extraction all read the *tagged* commit, not the default branch. A manual run therefore publishes exactly what the tag push would have.
- **Tag-shape guard** — rejects anything not matching `v[0-9]*` before doing any work.
- **Already-released guard** — `gh release view` short-circuits the run rather than letting a re-run overwrite a published release.

`CLAUDE.md`'s Releasing section documents the manual path alongside the tag push.

## Testing

Verified against the real `v5.1.0` tag in this repo:

- version guard — `git show v5.1.0:ship/VERSION` → `5.1.0`, matching the tag
- changelog extraction at that commit → the full 16-line `## 5.1.0` section
- tag-shape guard — `v5.1.0` accepted; `5.1.0`, `latest`, `vX` rejected
- workflow YAML parses; both triggers and all 8 steps resolve

## After merge

The v5.1.0 release can be published from **Actions → Release → Run workflow → `v5.1.0`**, with the tag left exactly where it is. I can trigger that run once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_013yF1AnjoCd6sEi9BABv57e)_